### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM tiangolo/uwsgi-nginx-flask:python3.7
+
+ENV LISTEN_PORT 3134
+EXPOSE 3134
+ENV PYTHONPATH=$PYTHONPATH:/app/python/
+ENV PYTHONPATH=$PYTHONPATH:/app/
+ENV STATIC_PATH /app/web/static
+ENV NGINX_MAX_UPLOAD 500m
+
+COPY ./uwsgi.ini /app/
+COPY ./python /app/python
+COPY ./web /app/web
+COPY ./requirements.txt /app/
+RUN apt-get clean && apt-get update && apt-get -y install cmake ca-certificates vim
+RUN pip3 install -r /app/requirements.txt
+RUN mkdir opensmile && cd opensmile && wget https://github.com/audeering/opensmile/releases/download/v3.0.0/opensmile-3.0-linux-x64.tar.gz && tar -xzvf opensmile-3.0-linux-x64.tar.gz && mv opensmile-3.0-linux-x64/* .
+
+WORKDIR /app/web

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Navigate to localhost:3134, preferably using Chrome. You might need to zoom out 
 
 Before processing audio of your own I recommend testing out the included examples, choose one from the header tab. See functionality and controls [here](misc/cheatsheet.pdf).
 
+### Docker
+
+Alternatively, to run the app using Docker, first [install Docker](https://docs.docker.com/get-docker/) and clone this repo (`git clone https://github.com/perfall/Edyson.git`). Then build your image by running `docker build -t edyson .` from the root of the cloned repo. Then you can start a container with your image by running `docker run -d --name edyson -p 3134:3134 edyson`.
+
 ## Process your audio
 Choose an audio file, wav or mp3. Select segment size (duration of snippet), step size (the duration between two consecutive snippets), and features (currently only MFCC and mean-normalized MFCC). Click process audio.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pycparser==2.19
 pydub==0.23.1
 pyparsing==2.4.0
 python-dateutil==2.8.0
-scikit-learn==0.20.3
+scikit-learn==0.21.3
 scipy==1.2.1
 six==1.12.0
 sklearn==0.0

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,3 @@
+[uwsgi]
+module = web.app
+callable = app

--- a/web/app.py
+++ b/web/app.py
@@ -137,7 +137,7 @@ def load_browser(session_key) -> str:
             chunks = metadata["chunks"]
             #chunks = "../" + metadata["audio_path"]
         except:
-            chunks = "../" + metadata["audio_path"]
+            chunks = os.path.join(os.path.dirname(__file__), "..", metadata["audio_path"])
         #chunks = re.sub("\[|\]|\,\'", "", metadata["chunks"]).split()
         print(chunks)
         print(type(chunks))
@@ -149,7 +149,7 @@ def load_browser(session_key) -> str:
                                 stepSize=metadata["step_size"],
                                 datapoints=len(data),
                                 session_key=session_key, 
-                                audioPath="../" + metadata["audio_path"],
+                                audioPath=metadata["audio_path"],
                                 audioPaths = chunks,
                                 examples = examples)
     else:


### PR DESCRIPTION
Hi @perfall, thanks for this great project! I had a tough time getting it set up on my Mac, and so I thought I would containerize it. The Docker related additions are in cbf9b3b and also include an addition to the Readme that details how to build and run the Docker image. I had to bump scikit-learn (a123d5a) and I also refactored some of the paths to use the `os.path` module as some of the paths changed when inside the container. The Docker container downloads openSMILE and unpacks it in the container. I believe this project was using v2.3 at some point, given the paths used for the config, however, I couldn't find pre-built binaries for v2.3 and so this is downloading and installing v3.0.0 now. The one place that there might be a breaking change then though is in the `config_dir` variable in `audio_processing`. This now has `mfcc` appended to the end of it, to match the openSMILE v3.0.0 file structure, but I'm not familiar with the rest of this code to know if that will cause problems. Anyways, I hope this is helpful in some way, it also now means that it can be deployed quite easily on say Heroku or other services that allow for deployments from Dockerfiles.

Thanks again!